### PR TITLE
fix(tabs): Accessibility and keyboard interaction fixes

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -307,6 +307,13 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
         event.preventDefault();
         if (!locked) select(ctrl.focusIndex);
         break;
+      case $mdConstant.KEY_CODE.TAB:
+        // On tabbing out of the tablist, reset hasFocus to reset ng-focused and
+        // its md-focused class if the focused tab is not the active tab.
+        if (ctrl.focusIndex !== ctrl.selectedIndex) {
+          ctrl.focusIndex = ctrl.selectedIndex;
+        }
+        break;
     }
   }
 
@@ -667,12 +674,12 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   }
 
   /**
-   * This is used to forward focus to dummy elements.  This method is necessary to avoid animation
-   * issues when attempting to focus an item that is out of view.
+   * This is used to forward focus to tab container elements.  This method is necessary to avoid
+   * animation issues when attempting to focus an item that is out of view.
    */
   function redirectFocus () {
     ctrl.styleTabItemFocus = ($mdInteraction.getLastInteractionType() === 'keyboard');
-    getElements().dummies[ ctrl.focusIndex ].focus();
+    getElements().tabs[ ctrl.focusIndex ].focus();
   }
 
   /**

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -131,27 +131,28 @@ function MdTabs ($$mdSvgRegistry) {
             '<md-icon md-svg-src="'+ $$mdSvgRegistry.mdTabsArrow +'"></md-icon> ' +
           '</md-next-button> ' +
           '<md-tabs-canvas ' +
-              'tabindex="{{ $mdTabsCtrl.hasFocus ? -1 : 0 }}" ' +
-              'aria-activedescendant="{{$mdTabsCtrl.getFocusedTabId()}}" ' +
               'ng-focus="$mdTabsCtrl.redirectFocus()" ' +
               'ng-class="{ ' +
                   '\'md-paginated\': $mdTabsCtrl.shouldPaginate, ' +
                   '\'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs ' +
               '}" ' +
-              'ng-keydown="$mdTabsCtrl.keydown($event)" ' +
-              'role="tablist"> ' +
+              'ng-keydown="$mdTabsCtrl.keydown($event)"> ' +
             '<md-pagination-wrapper ' +
                 'ng-class="{ \'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs }" ' +
-                'md-tab-scroll="$mdTabsCtrl.scroll($event)"> ' +
+                'md-tab-scroll="$mdTabsCtrl.scroll($event)" ' +
+                'role="tablist"> ' +
               '<md-tab-item ' +
-                  'tabindex="-1" ' +
+                  'tabindex="{{ tab.isActive() ? 0 : -1 }}" ' +
                   'class="md-tab" ' +
                   'ng-repeat="tab in $mdTabsCtrl.tabs" ' +
                   'role="tab" ' +
+                  'id="tab-item-{{::tab.id}}" ' +
                   'md-tab-id="{{::tab.id}}"' +
                   'aria-selected="{{tab.isActive()}}" ' +
                   'aria-disabled="{{tab.scope.disabled || \'false\'}}" ' +
                   'ng-click="$mdTabsCtrl.select(tab.getIndex())" ' +
+                  'ng-focus="$mdTabsCtrl.hasFocus = true" ' +
+                  'ng-blur="$mdTabsCtrl.hasFocus = false" ' +
                   'ng-class="{ ' +
                       '\'md-active\':    tab.isActive(), ' +
                       '\'md-focused\':   tab.hasFocus(), ' +
@@ -164,16 +165,10 @@ function MdTabs ($$mdSvgRegistry) {
                   'md-scope="::tab.parent"></md-tab-item> ' +
               '<md-ink-bar></md-ink-bar> ' +
             '</md-pagination-wrapper> ' +
-            '<md-tabs-dummy-wrapper class="md-visually-hidden md-dummy-wrapper"> ' +
+            '<md-tabs-dummy-wrapper aria-hidden="true" class="md-visually-hidden md-dummy-wrapper"> ' +
               '<md-dummy-tab ' +
                   'class="md-tab" ' +
                   'tabindex="-1" ' +
-                  'id="tab-item-{{::tab.id}}" ' +
-                  'md-tab-id="{{::tab.id}}"' +
-                  'aria-selected="{{tab.isActive()}}" ' +
-                  'aria-disabled="{{tab.scope.disabled || \'false\'}}" ' +
-                  'ng-focus="$mdTabsCtrl.hasFocus = true" ' +
-                  'ng-blur="$mdTabsCtrl.hasFocus = false" ' +
                   'ng-repeat="tab in $mdTabsCtrl.tabs" ' +
                   'md-tabs-template="::tab.label" ' +
                   'md-scope="::tab.parent"></md-dummy-tab> ' +

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -263,7 +263,7 @@ md-tab {
   box-sizing: border-box;
   overflow: hidden;
   text-overflow: ellipsis;
-  &.md-focused {
+  &.md-focused, &:focus {
     box-shadow: none;
     outline: none;
   }

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -129,7 +129,7 @@ describe('<md-tabs>', function () {
 
     }));
 
-    it('should select tab on space or enter', inject(function ($mdConstant) {
+    it('should select tab on space or enter', inject(function ($document, $mdConstant) {
       var tabs     = setup('<md-tabs>' +
                            '<md-tab></md-tab>' +
                            '<md-tab></md-tab>' +
@@ -140,10 +140,15 @@ describe('<md-tabs>', function () {
       triggerKeydown(tabs.find('md-tabs-canvas').eq(0), $mdConstant.KEY_CODE.RIGHT_ARROW);
       triggerKeydown(tabs.find('md-tabs-canvas').eq(0), $mdConstant.KEY_CODE.ENTER);
       expect(tabItems.eq(1)).toBeActiveTab();
+      expect(tabItems.eq(1).attr('tabindex')).toBe('0');
 
       triggerKeydown(tabs.find('md-tabs-canvas').eq(0), $mdConstant.KEY_CODE.LEFT_ARROW);
       triggerKeydown(tabs.find('md-tabs-canvas').eq(0), $mdConstant.KEY_CODE.SPACE);
       expect(tabItems.eq(0)).toBeActiveTab();
+      // Active tab should be added to the tab order as per ARIA practices.
+      expect(tabItems.eq(0).attr('tabindex')).toBe('0');
+      // Deactivated tab should be removed from the tab order.
+      expect(tabItems.eq(1).attr('tabindex')).toBe('-1');
     }));
 
     it('should bind to selected', function () {
@@ -157,14 +162,11 @@ describe('<md-tabs>', function () {
 
       expect(tabItems.eq(0)).toBeActiveTab();
       expect(tabs.scope().current).toBe(0);
-      expect(dummyTabs.eq(0).attr('aria-selected')).toBe('true');
 
       tabs.scope().$apply('current = 1');
       expect(tabItems.eq(1)).toBeActiveTab();
 
       expect(tabItems.eq(0).attr('aria-selected')).toBe('false');
-      expect(dummyTabs.eq(0).attr('aria-selected')).toBe('false');
-      expect(dummyTabs.eq(1).attr('aria-selected')).toBe('true');
 
       tabItems.eq(2).triggerHandler('click');
       expect(tabs.scope().current).toBe(2);
@@ -176,28 +178,43 @@ describe('<md-tabs>', function () {
                             '<md-tab ng-disabled="disabled1"></md-tab>' +
                             '</md-tabs>');
       var tabItems  = tabs.find('md-tab-item');
-      var dummyTabs = tabs.find('md-dummy-tab');
 
       expect(tabItems.eq(0)).toBeActiveTab();
-      expect(dummyTabs.eq(0).attr('aria-selected')).toBe('true');
+      expect(tabItems.eq(0).attr('aria-selected')).toBe('true');
 
       tabs.scope().$apply('disabled0 = true');
       expect(tabItems.eq(1)).toBeActiveTab();
 
       expect(tabItems.eq(0).attr('aria-disabled')).toBe('true');
-      expect(dummyTabs.eq(0).attr('aria-disabled')).toBe('true');
       expect(tabItems.eq(1).attr('aria-disabled')).toBe('false');
-      expect(dummyTabs.eq(1).attr('aria-disabled')).toBe('false');
 
       tabs.scope().$apply('disabled0 = false; disabled1 = true');
       expect(tabItems.eq(0)).toBeActiveTab();
 
       expect(tabItems.eq(0).attr('aria-disabled')).toBe('false');
-      expect(dummyTabs.eq(0).attr('aria-disabled')).toBe('false');
       expect(tabItems.eq(1).attr('aria-disabled')).toBe('true');
-      expect(dummyTabs.eq(1).attr('aria-disabled')).toBe('true');
     });
 
+  });
+
+  describe('leaving tablist', function() {
+
+    it('should reconcile focused and active tabs', inject(function($mdConstant) {
+      var tabs = setup('<md-tabs>' +
+                       '<md-tab label="super label"></md-tab>' +
+                       '<md-tab label="super label two"></md-tab>' +
+                       '</md-tabs>' +
+                       '<div tabindex="0">Focusable element</div>');
+      var ctrl = tabs.controller('mdTabs');
+      var tabItems = tabs.find('md-tab-item');
+      triggerKeydown(tabs.find('md-tabs-canvas').eq(0), $mdConstant.KEY_CODE.RIGHT_ARROW);
+      expect(tabItems.eq(0)).toBeActiveTab();
+      expect(ctrl.getFocusedTabId()).toBe(tabItems.eq(1).attr('id'));
+
+      triggerKeydown(tabs.find('md-tabs-canvas').eq(0), $mdConstant.KEY_CODE.TAB);
+      expect(tabItems.eq(0)).toBeActiveTab();
+      expect(ctrl.getFocusedTabId()).toBe(tabItems.eq(0).attr('id'));
+    }));
   });
 
   describe('tab label & content DOM', function () {
@@ -353,12 +370,12 @@ describe('<md-tabs>', function () {
       var tabs       = setup('<md-tabs>' +
                              '<md-tab label="label!">content!</md-tab>' +
                              '</md-tabs>');
-      var tabItem    = tabs.find('md-dummy-tab');
+      var tabItem    = tabs.find('md-tab-item');
       var tabContent = angular.element(tabs[ 0 ].querySelector('md-tab-content'));
 
       $timeout.flush();
 
-      expect(tabs.find('md-tabs-canvas').attr('role')).toBe('tablist');
+      expect(tabs.find('md-pagination-wrapper').attr('role')).toBe('tablist');
 
       expect(tabItem.attr('id')).toBeTruthy();
       expect(tabItem.attr('aria-controls')).toBe(tabContent.attr('id'));


### PR DESCRIPTION
This commit does a few things related to accessibility:
1) Hides md-dummy-tabs completely from screen readers with aria-hidden.
With this change, screen readers do not hear the dummy tabs read out
when using linear navigation. Instead of focusing the dummy tabs, the
visible tabs are focused. There was a comment that mentions focusing the
dummy tabs as a way to avoid animation issues; however, I could not
replicate the mentioned issues.
2) Fixes the ARIA roles so users can hear "tab 1 of 3" instead of just
"tab" by moving role="tablist" to the direct parent element (which
contains the items marked role="tab").
3) Fixes keyboard interaction to match recommended ARIA practices by
focusing on the active tab when using TAB navigation, then resolving the
focus/active tab discrepancy on pressing TAB within the tablist.
4) Note that there is a SCSS change added in to retain current behavior
when the active tab is added to the tab order; however, this should
likely be reconsidered as it actively overrides default focus outline
behavior.

Closes #10075.